### PR TITLE
Use dotenv.js for configuration parameter

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('nodejs-posgresql:server');
 var http = require('http');
+require('dotenv').config();
 
 /**
  * Get port from environment and store in Express.

--- a/config.js
+++ b/config.js
@@ -1,14 +1,14 @@
-const env = process.env;
+require('dotenv').config();
 
 const config = {
   db: { /* do not put password or any sensitive info here, done only for demo */
-    host: env.DB_HOST || 'otto.db.elephantsql.com',
-    port: env.DB_PORT || '5432',
-    user: env.DB_USER || 'cklijfef',
-    password: env.DB_PASSWORD || 'V1qidES5k3DSJICDRgXtyT8qeu2SPCZp',
-    database: env.DB_NAME || 'cklijfef',
+    host: process.env.DB_HOST || 'otto.db.elephantsql.com',
+    port: process.env.DB_PORT || '5432',
+    user: process.env.DB_USER || 'cklijfef',
+    password: process.env.DB_PASSWORD || 'V1qidES5k3DSJICDRgXtyT8qeu2SPCZp',
+    database: process.env.DB_NAME || 'cklijfef',
   },
-  listPerPage: env.LIST_PER_PAGE || 10,
+  listPerPage: process.env.LIST_PER_PAGE || 10,
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
+    "dotenv": "^16.0.0",
     "express": "~4.16.1",
     "morgan": "~1.9.1",
     "pg": "^8.5.1"


### PR DESCRIPTION
Hi @geshan ,
I was wondering if you are interested to use ```Dotenv.js``` to set environment parameter in alternative way.

At the moment, you can set environment parameter using a call like this.

```bash
DB_PORT=65534 PORT=65535 DEBUG=nodejs-posgresql:server ./bin/www 
  nodejs-posgresql:server Listening on port 65535 +0ms
```

Adding ```Dotenv.js``` you can alternatively also set environment parameter using an ```.env``` file like this

```
PORT=3000
DB_HOST='otto.db.elephantsql.com'
DB_PORT='5432'
DB_USER='cklijfef'
DB_PASSWORD='V1qidES5k3DSJICDRgXtyT8qeu2SPCZp'
DB_NAME='cklijfef'
```

and call the service like this.

```bash
DEBUG=nodejs-posgresql:server ./bin/www 
  nodejs-posgresql:server Listening on port 3000 +5ms
GET /quotes?req&query&page=13 200 119.041 ms - 1568
```

Please feel free to use, study, improve or share this PR.

Cheers!